### PR TITLE
fix(ci): 修复 check-base-image-digest workflow 创建 Issue 权限不足问题

### DIFF
--- a/.github/workflows/check-base-image-digest.yml
+++ b/.github/workflows/check-base-image-digest.yml
@@ -5,6 +5,11 @@ on:
     - cron: '0 0 * * *'  # 每天 UTC 00:00 运行
   workflow_dispatch:  # 允许手动触发
 
+# 授予 GITHUB_TOKEN 创建 Issue 的权限（schedule 触发的 workflow 默认无 issues:write）
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-digest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 问题描述

GitHub Actions 定时任务 **Check Base Image Digest** 运行失败（[Run #31232674033](https://github.com/xiaomizhoubaobei/302_image_toolbox/actions/runs/31232674033)），失败步骤为 `Create issue on digest change`。

**失败日志**：
```
Unhandled error: HttpError: Resource not accessible by integration
```

## 根因分析

该 workflow 由 `schedule` 触发，而 **schedule 触发的 workflow 中 `GITHUB_TOKEN` 默认只有只读权限**（Contents/Metadata/Packages 均为 read），未授予 `issues: write` 权限。

当基础镜像 digest 发生变化（本次检测到 `node:lts` 镜像 digest 已从 `sha256:8530...` 更新为 `sha256:9342...`）时，workflow 需要通过 `github-script` 调用 `issues.create` 创建提醒 Issue，但因 token 无 `issues: write` 权限而报错。

## 修复内容

在 `.github/workflows/check-base-image-digest.yml` 顶部显式声明 `permissions`，为 `GITHUB_TOKEN` 授予 `issues: write` 权限：

```yaml
permissions:
  contents: read
  issues: write
```

这样当检测到基础镜像 digest 更新时，workflow 即可正常创建提醒 Issue。

## 验证

- 已通过 `git commit -S` 使用 GPG 密钥签名提交

## GPG 签名信息

- **密钥ID**：`39D86F84805EE993`
- **密钥身份**：qixiaoxin@stu.sqxy.edu.cn
- **签名方式**：GPG 签名提交

关联 CI 运行：[Run #31232674033](https://github.com/xiaomizhoubaobei/302_image_toolbox/actions/runs/31232674033)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Add explicit permissions to the check-base-image-digest workflow so GITHUB_TOKEN can write issues while keeping contents read-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated workflow permissions to allow read-only repository access and issue creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->