### PR TITLE
更新 node:lts 基础镜像 digest 至最新安全版本

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts@sha256:8530f76a96d88820d288761f022e318970dda93d01536919fbc16076b7983e63 AS build
+FROM node:lts@sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584 AS build
 
 WORKDIR /app
 
@@ -21,7 +21,7 @@ COPY . .
 RUN yarn build
 
 # -------- Production Image Setup --------
-FROM node:lts@sha256:8530f76a96d88820d288761f022e318970dda93d01536919fbc16076b7983e63 AS production
+FROM node:lts@sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584 AS production
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## 变更内容

根据 GitHub Issue #73 的安全提醒，将 `Dockerfile` 中 `node:lts` 基础镜像的 digest 更新至最新版本：

| 阶段 | 更新前 | 更新后 |
|------|--------|--------|
| build | `sha256:8530f76a...` | `sha256:934240a1...` |
| production | `sha256:8530f76a...` | `sha256:934240a1...` |

具体更新为 `node:lts@sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584`。

## 关联 Issue

Fixes #73

## 验证

- 已通过 pre-commit 全部检查（gitleaks / trailing-whitespace / end-of-file-fixer / check-yaml / check-added-large-files / check-toml）
- 提交使用 GPG 签名

## GPG 签名信息

- **密钥ID**：`97CD918AF3513964`
- **密钥身份**：qixiaoxin@stu.sqxy.edu.cn
- **签名方式**：GPG 签名提交


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Node.js base image used during build and production deployment.
  * Improved image consistency and reproducibility by refreshing the pinned image reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->